### PR TITLE
ICC v2.2.1 for mediaset profile

### DIFF
--- a/cli/cluster.js
+++ b/cli/cluster.js
@@ -7,6 +7,7 @@ import { debug, info, error } from '../lib/utils.js'
 import * as platformatic from '../lib/platformatic.js'
 import * as psql from '../lib/psql.js'
 import * as kubectl from '../lib/kubectl.js'
+import { setTimeout } from 'node:timers/promises'
 
 export const options = { command: 'cluster', strict: true }
 
@@ -39,6 +40,7 @@ export default async function cli (argv) {
       // HACKS The problem is ownership of the sql
       info('Preparing database for Platformatic')
       const { postgres } = await getClusterStatus({ context })
+      await setTimeout(3000) // wait a bit more to avoid "psql: error: could not connect to server: Connection refused"
       await psql.execute(postgres.connectionString, join(context.chartDir, 'platformatic/helm', 'docker-postgres-init.sql'))
 
       info(`Installing Platformatic "${context.name}" profile`)

--- a/profiles/customer-mediaset.yaml
+++ b/profiles/customer-mediaset.yaml
@@ -39,7 +39,7 @@ platformatic:
   projects:
     icc:
       image:
-        tag: "v2.1.3"
+        tag: "v2.2.1"
         repository: "ghcr.io/platformatic/plt-icc-3"
       path: ''
       overrides:


### PR DESCRIPTION
To run it:

- docker pull platformatic/enterprise-icc:v2.2.1
- docker pull platformatic/machinist:v2.0.0  
- in `.env` set:
```
PULL_SECRET_USER=xxxx
PULL_SECRET_TOKEN=ghp_yyyy
```
Run with: 
```
desk cluster up --profile customer-mediaset  
```