### PR TITLE
feat: add --npmrc flag to deploy command for private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ When `--replicas` is provided, both `icc.platformatic.dev/scaler-min` and
 The Deployment's `spec.replicas` is set to the min value for immediate scaling
 on the initial deploy.
 
+Deploy with a custom `.npmrc` for private npm packages:
+
+```sh
+desk deploy --profile <name> --dir ./my-app --npmrc ./project/.npmrc
+```
+
+By default, `~/.npmrc` is used if it exists. The Dockerfile must mount the
+secret during install:
+
+```dockerfile
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm install
+```
+
 Deploy with an environment file:
 
 > [!WARNING]

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -23,7 +23,8 @@ export default async function cli (argv) {
       'hostname',
       'replicas',
       'min-replicas',
-      'max-replicas'
+      'max-replicas',
+      'npmrc'
     ],
     alias: {
       dir: 'd',
@@ -75,7 +76,7 @@ export default async function cli (argv) {
       // Dockerfile not found or unreadable — skip detection
     }
 
-    await registry.buildFromDirectory(directory, appImage)
+    await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc })
   } else {
     appName = appImage.split(':')[0].split('/').pop()
   }
@@ -115,7 +116,7 @@ export default async function cli (argv) {
       maxReplicas = parseInt(args['max-replicas'], 10)
     }
   }
-  
+
   await deploy.createDeployment(appName, appImage, args.namespace, envVars, args['dry-run'], { context, version, isWorkflow, hostname, minReplicas, maxReplicas })
   await deploy.createService(appName, appImage, args.namespace, args['dry-run'], { context, version, isWorkflow, headless: args.headless })
 

--- a/docs/deploy.txt
+++ b/docs/deploy.txt
@@ -16,4 +16,34 @@ Flags:
 	    --replicas		Number of replicas (sets both min and max)
 	    --min-replicas		Minimum number of replicas for autoscaling
 	    --max-replicas		Maximum number of replicas for autoscaling
+	    --npmrc		Path to .npmrc file for Docker build (default: ~/.npmrc)
 	    --dry-run		Preview the deployment without applying
+
+Examples:
+	# Deploy from a local directory
+	desk deploy -p development -d ./my-app
+
+	# Deploy a pre-built image
+	desk deploy -p development -i registry.example.com/my-app:latest
+
+	# Deploy with environment variables from a file
+	desk deploy -p development -d ./my-app -e .env
+
+	# Deploy with a custom .npmrc for private packages
+	desk deploy -p development -d ./my-app --npmrc ./project/.npmrc
+
+	  The Dockerfile must mount the secret during npm install:
+
+	    RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm install
+
+	# Deploy a specific version with a custom hostname
+	desk deploy -p development -d ./my-app -v 1.2.0 --hostname myapp.example.com
+
+	# Deploy as a headless service (no gateway route, direct DNS access)
+	desk deploy -p development -d ./my-app --headless
+
+	# Set a fixed number of replicas
+	desk deploy -p development -d ./my-app --replicas 3
+
+	# Preview deployment without applying
+	desk deploy -p development -d ./my-app --dry-run

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -24,7 +24,7 @@ export async function start (registryConfig) {
   }
 }
 
-export async function buildFromDirectory (directory, tag, includeNpmrc = true, buildArgs = {}) {
+export async function buildFromDirectory (directory, tag, { npmrc, buildArgs = {} } = {}) {
   const dockerfilePath = join(directory, 'Dockerfile')
   if (!existsSync(dockerfilePath)) throw new Error(`No Dockerfile found in ${directory}`)
 
@@ -35,7 +35,10 @@ export async function buildFromDirectory (directory, tag, includeNpmrc = true, b
     `--file=${dockerfilePath}`,
   ]
 
-  if (includeNpmrc) args.push(`--secret=id=npmrc,src=${join(homedir(), '.npmrc')}`)
+  const npmrcPath = npmrc || join(homedir(), '.npmrc')
+  if (existsSync(npmrcPath)) {
+    args.push(`--secret=id=npmrc,src=${npmrcPath}`)
+  }
 
   args = args.concat(Object.entries(buildArgs).map(([key, value]) => {
     return `--build-arg=${key}=${value}`


### PR DESCRIPTION
## Summary
- Add `--npmrc` flag to `desk deploy` so users can specify a custom `.npmrc` path for Docker builds that need access to private npm packages
- Refactor `buildFromDirectory` to use an options object instead of positional args, and only mount the npmrc secret when the file actually exists (falls back to `~/.npmrc` by default)
- Add examples section to deploy help text covering all available flags
