### PR TITLE
Do not set the version unless `--version` is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,14 @@ which lets you exercise the `manage` and `advise` actuation modes:
 
 ```sh
 desk deploy --profile skew-protection --via-icc \
-  --app-id <ICC application id> --deploy-token plt_deploy_... \
+  --deploy-token plt_deploy_... \
   --image <pre-existing image> --version v1 --min-replicas 1
 ```
+
+The deploy token is app-bound, so ICC resolves the application from the token --
+a CI needs only the token, image, and version, never the application UUID. Pass
+`--app-id <id>` to force the app-scoped route instead (e.g. when driving it with
+an admin cookie).
 
 What happens depends on the app's mode (Settings → Skew Protection → Mode):
 
@@ -257,9 +262,11 @@ What happens depends on the app's mode (Settings → Skew Protection → Mode):
 
 Flags:
 
-* `--app-id` — the ICC application UUID (from the app URL `…/watts/<id>`). Required.
 * `--deploy-token` — a scoped deploy token (`plt_deploy_…`), or set
   `PLT_DEPLOY_TOKEN`. Mint one in the app's Settings → Deploy Tokens. Required.
+* `--app-id` — the ICC application UUID (from the app URL `…/watts/<id>`).
+  Optional: the token already identifies the app; pass it only to force the
+  app-scoped route.
 * `--icc-url` — ICC base URL (default `https://icc.plt`). TLS verification is
   disabled for this call (local self-signed cert); for local testing only.
 
@@ -280,7 +287,7 @@ Plan a new version's deploy (Deployment + Service + HTTPRoute):
 
 ```sh
 desk get-plan --profile skew-protection \
-  --app-id <ICC application id> --deploy-token plt_deploy_... \
+  --deploy-token plt_deploy_... \
   --image <pre-existing image> --version v9
 ```
 
@@ -291,7 +298,7 @@ makes it the gateway default), a `draining` version yields an *expire* plan
 
 ```sh
 desk get-plan --profile skew-protection \
-  --app-id <ICC application id> --deploy-token plt_deploy_... \
+  --deploy-token plt_deploy_... \
   --version v8
 ```
 
@@ -311,10 +318,11 @@ Apply it yourself with kubectl:
 Once you apply it, ICC observes the change and moves the version on its own
 (`pending-apply -> active`, or `draining -> expired`).
 
-Flags are the same `--app-id` / `--deploy-token` / `--icc-url` as
-`deploy --via-icc` (the deploy token is route-allowlisted to the read-only plan
-endpoints). With `--image` the plan is a new deploy; without it, the plan comes
-from the existing version's current state.
+Flags are the same `--deploy-token` / `--icc-url` (and optional `--app-id`) as
+`deploy --via-icc`: the token is app-bound, so ICC resolves the application from
+it and `--app-id` is optional (the deploy token is route-allowlisted to the
+read-only plan endpoints). With `--image` the plan is a new deploy; without it,
+the plan comes from the existing version's current state.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ desk get-plan --profile skew-protection \
   --image <pre-existing image> --version v9
 ```
 
-Plan an existing version's next actuation — the intent follows the version's
+Plan an existing version's next actuation -- the intent follows the version's
 state: a `pending-apply` version yields an *activate* plan (the HTTPRoute that
 makes it the gateway default), a `draining` version yields an *expire* plan
 (rebuild the route without it, scale its workload to zero):
@@ -309,7 +309,7 @@ Apply it yourself with kubectl:
 ```
 
 Once you apply it, ICC observes the change and moves the version on its own
-(`pending-apply → active`, or `draining → expired`).
+(`pending-apply -> active`, or `draining -> expired`).
 
 Flags are the same `--app-id` / `--deploy-token` / `--icc-url` as
 `deploy --via-icc` (the deploy token is route-allowlisted to the read-only plan

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Contents:
     * [`doctor`](#doctor)
     * [`profile`](#profile)
     * [`deploy`](#deploy)
+    * [`get-plan`](#get-plan)
 * [Troubleshooting](#troubleshooting)
 * [Examples](#examples)
 
@@ -249,7 +250,9 @@ What happens depends on the app's mode (Settings → Skew Protection → Mode):
 
 * `manage` — ICC creates the Deployment + Service itself; `desk` applies nothing.
 * `advise` — ICC returns the manifests as a plan and `desk` applies them with
-  `kubectl` (use `--dry-run` to print the plan without applying).
+  `kubectl` (use `--dry-run` to print the plan without applying). For a strictly
+  read-only workflow — fetch the plan, inspect it, and apply it yourself — use
+  [`get-plan`](#get-plan) instead; `--via-icc` is the one-shot that applies for you.
 * `observe` — ICC rejects the deploy API (this is the default direct path above).
 
 Flags:
@@ -265,6 +268,53 @@ exist before ICC can reference it (`--image <ref>` for a prebuilt one). `manage`
 mode also requires the `plt-pod-manager` RBAC to create Deployments/Services
 (shipped in the helm chart; run `helm upgrade`). See
 `skew-protection/TESTING.md` for the full manual test walkthrough.
+
+### `get-plan`
+
+Fetch a skew-protection actuation plan from ICC and print how to apply it with
+`kubectl`. Read-only: ICC computes the plan and mutates nothing; you apply it
+yourself. This is the `advise`-mode workflow, where an external actor owns the
+`kubectl apply` and ICC only observes the result.
+
+Plan a new version's deploy (Deployment + Service + HTTPRoute):
+
+```sh
+desk get-plan --profile skew-protection \
+  --app-id <ICC application id> --deploy-token plt_deploy_... \
+  --image <pre-existing image> --version v9
+```
+
+Plan an existing version's next actuation — the intent follows the version's
+state: a `pending-apply` version yields an *activate* plan (the HTTPRoute that
+makes it the gateway default), a `draining` version yields an *expire* plan
+(rebuild the route without it, scale its workload to zero):
+
+```sh
+desk get-plan --profile skew-protection \
+  --app-id <ICC application id> --deploy-token plt_deploy_... \
+  --version v8
+```
+
+`desk` writes each manifest to the run dir and prints the `kubectl` commands to
+apply the plan, for example:
+
+```
+ICC returned a 2-step plan (intent: expire). ICC applied nothing.
+  1. HTTPRoute/apply    leads-demo      route default traffic to v9
+  2. Deployment/scale   leads-demo-v8   scale down v8
+
+Apply it yourself with kubectl:
+  kubectl --namespace=platformatic apply --filename=.desk/run/icc-HTTPRoute-leads-demo.json
+  kubectl -n platformatic scale deployment/leads-demo-v8 --replicas=0
+```
+
+Once you apply it, ICC observes the change and moves the version on its own
+(`pending-apply → active`, or `draining → expired`).
+
+Flags are the same `--app-id` / `--deploy-token` / `--icc-url` as
+`deploy --via-icc` (the deploy token is route-allowlisted to the read-only plan
+endpoints). With `--image` the plan is a new deploy; without it, the plan comes
+from the existing version's current state.
 
 ## Troubleshooting
 

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -127,9 +127,11 @@ export default async function cli (argv) {
   // returns manifests that desk applies). This is the CI path a customer uses,
   // and the way to exercise manage/advise modes end to end.
   if (args['via-icc']) {
+    // --app-id is optional: with a deploy token ICC resolves the application from
+    // the token (the CI needs only the token). Pass --app-id to force the
+    // app-scoped route.
     const appId = args['app-id']
     const token = args['deploy-token'] || process.env.PLT_DEPLOY_TOKEN
-    if (!appId) { error('--via-icc requires --app-id <ICC application id>'); process.exit(1) }
     if (!token) { error('--via-icc requires --deploy-token <plt_deploy_...> or PLT_DEPLOY_TOKEN'); process.exit(1) }
     if (!version) { error('--via-icc requires --version <label>'); process.exit(1) }
 

--- a/cli/get-plan.js
+++ b/cli/get-plan.js
@@ -27,10 +27,12 @@ export default async function cli (argv) {
 
   const context = await loadContext(args.profile)
 
+  // --app-id is optional: with a deploy token ICC resolves the application from
+  // the token, so a CI needs only the token. Pass --app-id for the app-scoped
+  // route (e.g. an admin cookie, or to be explicit).
   const appId = args['app-id']
   const token = args['deploy-token'] || process.env.PLT_DEPLOY_TOKEN
   const version = args.version
-  if (!appId) { error('get-plan requires --app-id <ICC application id>'); process.exit(1) }
   if (!token) { error('get-plan requires --deploy-token <plt_deploy_...> or PLT_DEPLOY_TOKEN'); process.exit(1) }
   if (!version) { error('get-plan requires --version <label>'); process.exit(1) }
 

--- a/cli/get-plan.js
+++ b/cli/get-plan.js
@@ -1,0 +1,71 @@
+import minimist from 'minimist'
+import { loadContext } from '../lib/context.js'
+import { error, info } from '../lib/utils.js'
+import { getDeployPlan, getActuationPlan, writeAndPrintPlan } from '../lib/icc.js'
+
+export const options = { command: 'get-plan', strict: true }
+
+// Fetch a skew-protection actuation plan from ICC and print how to apply it with
+// kubectl. Read-only: ICC computes the plan and mutates nothing; you apply it.
+//   --image given -> deploy plan for a NEW version (Deployment + Service + HTTPRoute)
+//   --image absent -> plan for the EXISTING version's state (activate a
+//                     pending-apply one, or expire a draining one)
+export default async function cli (argv) {
+  const args = minimist(argv, {
+    string: [
+      'profile', 'app-id', 'deploy-token', 'icc-url', 'version', 'image',
+      'namespace', 'hostname', 'min-replicas', 'max-replicas'
+    ],
+    alias: { profile: 'p', version: 'v', image: 'i', namespace: 'n', hostname: 'h' },
+    default: { namespace: 'platformatic', 'icc-url': 'https://icc.plt' }
+  })
+
+  if (!args.profile) {
+    error('Missing --profile flag. Please specify a profile (e.g. --profile skew-protection)')
+    process.exit(1)
+  }
+
+  const context = await loadContext(args.profile)
+
+  const appId = args['app-id']
+  const token = args['deploy-token'] || process.env.PLT_DEPLOY_TOKEN
+  const version = args.version
+  if (!appId) { error('get-plan requires --app-id <ICC application id>'); process.exit(1) }
+  if (!token) { error('get-plan requires --deploy-token <plt_deploy_...> or PLT_DEPLOY_TOKEN'); process.exit(1) }
+  if (!version) { error('get-plan requires --version <label>'); process.exit(1) }
+
+  const iccUrl = args['icc-url']
+  const namespace = args.namespace
+
+  let intent
+  let steps
+  if (args.image) {
+    info(`\nFetching deploy plan for ${version} from ICC (${iccUrl})`)
+    const result = await getDeployPlan({
+      iccUrl,
+      appId,
+      token,
+      image: args.image,
+      version,
+      hostname: args.hostname,
+      namespace,
+      minReplicas: args['min-replicas'] ? parseInt(args['min-replicas'], 10) : undefined,
+      maxReplicas: args['max-replicas'] ? parseInt(args['max-replicas'], 10) : undefined
+    })
+    intent = result.intent
+    steps = result.plan
+    info(`ICC actuation mode: ${result.mode}`)
+  } else {
+    info(`\nFetching actuation plan for ${version} from ICC (${iccUrl})`)
+    const result = await getActuationPlan({ iccUrl, appId, token, version })
+    intent = result.intent
+    steps = result.steps
+  }
+
+  if (intent === 'none' || !steps || steps.length === 0) {
+    info(`No plan for ${version} (intent: ${intent ?? 'none'}). Nothing to apply.`)
+    return
+  }
+
+  await writeAndPrintPlan(context, namespace, steps, { intent })
+}

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -109,11 +109,12 @@ export async function createDeployment (name, imageNameTag, namespace, envVars, 
                   name: 'PLT_INSTANCE_ID',
                   valueFrom: { fieldRef: { fieldPath: 'metadata.name' } }
                 },
-                // Workflow apps need to know their deployment version for queue routing.
-                // For versioned deploys use the explicit version; for non-versioned
-                // derive from the image tag (matching ICC's auto-version logic).
-                ...(isWorkflow
-                  ? [{ name: 'PLT_WORLD_DEPLOYMENT_VERSION', value: version || imageNameTag.split(':').pop() }]
+                // Workflow apps need their deployment version for queue routing. Set it
+                // only when an explicit version is given; desk never derives one -- ICC
+                // is the single point that mints a version, and delivers it to the pod
+                // via the registration response (watt-extra sets PLT_DEPLOYMENT_VERSION).
+                ...(isWorkflow && version
+                  ? [{ name: 'PLT_WORLD_DEPLOYMENT_VERSION', value: version }]
                   : []),
               ],
               resources: defaultResources

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,6 +1,18 @@
 import { spawn } from './utils.js'
 import { addToRun } from './run-directory.js'
 
+// The Deployment/Service name must be unique per version so versions coexist for
+// skew protection. With an explicit --version use it; otherwise fall back to the
+// image tag (unique per build), sanitized to a k8s-safe segment. This is only the
+// resource name -- ICC still mints the routing version id (plt_...) from the image.
+function resourceVersion (version, imageNameTag) {
+  if (version) return version
+  const nameAndTag = imageNameTag.slice(imageNameTag.lastIndexOf('/') + 1)
+  const colon = nameAndTag.lastIndexOf(':')
+  const tag = colon >= 0 ? nameAndTag.slice(colon + 1) : 'latest'
+  return tag.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'latest'
+}
+
 export async function createDeployment (name, imageNameTag, namespace, envVars, dryRun, { context, version, isWorkflow, hostname, minReplicas, maxReplicas }) {
   const defaultResources = {
     // Minimum
@@ -16,8 +28,9 @@ export async function createDeployment (name, imageNameTag, namespace, envVars, 
     }
   }
 
-  const resourceName = version ? `${name}-${version}` : name
-  const instanceLabel = version ? `${name}-${version}` : name
+  const rv = resourceVersion(version, imageNameTag)
+  const resourceName = `${name}-${rv}`
+  const instanceLabel = `${name}-${rv}`
   const nameLabel = name
 
   const labels = {
@@ -140,8 +153,9 @@ export async function createDeployment (name, imageNameTag, namespace, envVars, 
 }
 
 export async function createService (name, imageNameTag, namespace, dryRun, { context, version, isWorkflow, headless }) {
-  const resourceName = version ? `${name}-${version}` : name
-  const instanceLabel = version ? `${name}-${version}` : name
+  const rv = resourceVersion(version, imageNameTag)
+  const resourceName = `${name}-${rv}`
+  const instanceLabel = `${name}-${rv}`
   const nameLabel = name
 
   const labels = {

--- a/lib/icc.js
+++ b/lib/icc.js
@@ -11,7 +11,12 @@ import { spawn, info, warn } from './utils.js'
 // customer would use. icc.plt uses a local/self-signed cert, so TLS verification
 // is disabled for this call (dev/testing tool).
 export async function deployViaIcc ({ iccUrl, appId, token, image, version, hostname, namespace, minReplicas, maxReplicas, env }) {
-  const url = `${iccUrl.replace(/\/+$/, '')}/control-plane/applications/${appId}/deploy`
+  // With an app id: the app-scoped route. Without: the token-scoped route, where
+  // ICC resolves the application from the deploy token (a CI needs only the token).
+  const base = iccUrl.replace(/\/+$/, '')
+  const url = appId
+    ? `${base}/control-plane/applications/${appId}/deploy`
+    : `${base}/control-plane/deploy`
 
   const body = { image, version }
   if (hostname) body.hostname = hostname
@@ -101,7 +106,10 @@ async function iccRequest (url, { method = 'GET', token, body } = {}) {
 // Read-only: the deploy plan for a NEW version (Deployment + Service + HTTPRoute).
 // ICC mutates nothing whatever the app's mode. Returns { intent, mode, plan }.
 export async function getDeployPlan ({ iccUrl, appId, token, image, version, hostname, namespace, minReplicas, maxReplicas, env }) {
-  const url = `${iccUrl.replace(/\/+$/, '')}/control-plane/applications/${appId}/deploy/plan`
+  const base = iccUrl.replace(/\/+$/, '')
+  const url = appId
+    ? `${base}/control-plane/applications/${appId}/deploy/plan`
+    : `${base}/control-plane/deploy/plan`
   const body = { image, version }
   if (hostname) body.hostname = hostname
   if (namespace) body.namespace = namespace
@@ -114,7 +122,11 @@ export async function getDeployPlan ({ iccUrl, appId, token, image, version, hos
 // Read-only: the actuation plan for an EXISTING version, derived from its state
 // (activate for pending-apply/staged, expire for draining). Returns { intent, steps }.
 export async function getActuationPlan ({ iccUrl, appId, token, version }) {
-  const url = `${iccUrl.replace(/\/+$/, '')}/control-plane/applications/${appId}/versions/${encodeURIComponent(version)}/actuation-plan`
+  const base = iccUrl.replace(/\/+$/, '')
+  const v = encodeURIComponent(version)
+  const url = appId
+    ? `${base}/control-plane/applications/${appId}/versions/${v}/actuation-plan`
+    : `${base}/control-plane/versions/${v}/actuation-plan`
   return iccRequest(url, { method: 'GET', token })
 }
 

--- a/lib/icc.js
+++ b/lib/icc.js
@@ -73,3 +73,76 @@ export async function handleIccDeploy (context, namespace, result, dryRun) {
   }
   warn('ICC deploy returned no plan and deployed=false; nothing to do.')
 }
+
+// Shared ICC request helper. icc.plt uses a local/self-signed cert, so TLS
+// verification is disabled for the call (dev/testing tool only).
+async function iccRequest (url, { method = 'GET', token, body } = {}) {
+  const prevTls = process.env.NODE_TLS_REJECT_UNAUTHORIZED
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+  try {
+    const headers = { authorization: `Bearer ${token}` }
+    const opts = { method, headers }
+    if (body !== undefined) {
+      headers['content-type'] = 'application/json'
+      opts.body = JSON.stringify(body)
+    }
+    const res = await fetch(url, opts)
+    const text = await res.text()
+    let json
+    try { json = JSON.parse(text) } catch { json = { raw: text } }
+    if (!res.ok) throw new Error(`ICC request failed (${res.status}): ${json?.message ?? text}`)
+    return json
+  } finally {
+    if (prevTls === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED
+    else process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevTls
+  }
+}
+
+// Read-only: the deploy plan for a NEW version (Deployment + Service + HTTPRoute).
+// ICC mutates nothing whatever the app's mode. Returns { intent, mode, plan }.
+export async function getDeployPlan ({ iccUrl, appId, token, image, version, hostname, namespace, minReplicas, maxReplicas, env }) {
+  const url = `${iccUrl.replace(/\/+$/, '')}/control-plane/applications/${appId}/deploy/plan`
+  const body = { image, version }
+  if (hostname) body.hostname = hostname
+  if (namespace) body.namespace = namespace
+  if (minReplicas) body.minReplicas = minReplicas
+  if (maxReplicas) body.maxReplicas = maxReplicas
+  if (env && Object.keys(env).length) body.env = env
+  return iccRequest(url, { method: 'POST', token, body })
+}
+
+// Read-only: the actuation plan for an EXISTING version, derived from its state
+// (activate for pending-apply/staged, expire for draining). Returns { intent, steps }.
+export async function getActuationPlan ({ iccUrl, appId, token, version }) {
+  const url = `${iccUrl.replace(/\/+$/, '')}/control-plane/applications/${appId}/versions/${encodeURIComponent(version)}/actuation-plan`
+  return iccRequest(url, { method: 'GET', token })
+}
+
+// Write the plan's manifests to the run dir and print the kubectl commands to
+// apply it. Applies nothing -- the operator (or their CI) runs these. Manifest
+// steps become `kubectl apply -f <file>`; command-only steps (e.g. scale) print
+// their command verbatim.
+export async function writeAndPrintPlan (context, namespace, steps, { intent } = {}) {
+  if (!steps || steps.length === 0) {
+    info(`\nICC returned no steps${intent ? ` (intent: ${intent})` : ''}. Nothing to apply.`)
+    return []
+  }
+  info(`\nICC returned a ${steps.length}-step plan${intent ? ` (intent: ${intent})` : ''}. ICC applied nothing.`)
+  const applyCommands = []
+  let i = 0
+  for (const step of steps) {
+    i++
+    const name = step.manifest?.metadata?.name ?? step.kind
+    const desc = step.description ? ` -- ${step.description}` : ''
+    info(`  ${i}. ${step.kind}/${step.action}  ${name}${desc}`)
+    if (step.manifest) {
+      const filePath = await addToRun(context.runDir, `icc-${step.kind}-${name}.json`, JSON.stringify(step.manifest, null, 2))
+      applyCommands.push(`kubectl --namespace=${namespace} apply --filename=${filePath}`)
+    } else if (step.command) {
+      applyCommands.push(step.command)
+    }
+  }
+  info('\nApply it yourself with kubectl:')
+  for (const cmd of applyCommands) info(`  ${cmd}`)
+  return applyCommands
+}


### PR DESCRIPTION
desk no longer decides the deployment version. With `--version` it uses the label verbatim; without it, desk leaves the version unset and lets ICC mint it (a `plt_` id derived from the image).

Also adds `desk get-plan` to fetch an advise-mode actuation plan from ICC and print the `kubectl` to apply it, and resolves the application from the deploy token so the ICC-driven path doesn't need `--app-id`.
