### PR TITLE
fix: Improve deployment metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,10 +424,12 @@ desk deploy --profile skew-protection --dir ./my-app --version v2
 ICC will detect the new versions via pod labels and create HTTPRoute rules to
 route traffic to the correct version based on the `__plt_dpl` cookie.
 
-For workflow apps (apps with `WORKFLOW_TARGET_WORLD=@platformatic/world` in the
-Dockerfile), ICC automatically registers queue handlers with the workflow service
-and uses workflow-aware draining — keeping old versions alive until active
-workflows complete.
+Workflow apps declare `PLT_WORKFLOW=true` with a Dockerfile `ENV` instruction or
+in the file passed to `--envfile`. Set it explicitly to `false` to disable workflow
+classification. ICC then registers queue handlers with the workflow service and
+uses workflow-aware draining, keeping old versions alive until active workflows
+complete. `WORKFLOW_TARGET_WORLD=@platformatic/world` in the Dockerfile remains a
+compatibility fallback.
 
 ### Testing ICC Installation Script
 

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -6,10 +6,15 @@ import { loadContext } from '../lib/context.js'
 import { error, info } from '../lib/utils.js'
 import * as registry from '../lib/registry.js'
 import * as deploy from '../lib/deploy.js'
-import { deployViaIcc, handleIccDeploy } from '../lib/icc.js'
+import { deployViaIcc, handleIccDeploy, writeAndPrintPlan } from '../lib/icc.js'
 import { getClusterStatus } from '../lib/cluster/index.js'
+import { detectWorkflow } from '../lib/workflow.js'
 
 export const options = { command: 'deploy', strict: true }
+
+export function imageName (image) {
+  return image.split('/').at(-1).split('@')[0].split(':')[0]
+}
 
 export default async function cli (argv) {
   const args = minimist(argv, {
@@ -39,10 +44,7 @@ export default async function cli (argv) {
       version: 'v',
       hostname: 'h'
     },
-    default: {
-      namespace: 'platformatic',
-      'icc-url': 'https://icc.plt'
-    }
+    default: { 'icc-url': 'https://icc.plt' }
   })
 
   if (!args.profile) {
@@ -62,30 +64,6 @@ export default async function cli (argv) {
     process.exit(1)
   }
 
-  let appImage = args.image
-  let appName
-  let isWorkflow = false
-  if (args.dir) {
-    const directory = resolve(args.dir)
-    appName = basename(directory).split(sep).pop()
-    appImage = `plt.localreg/plt-local/${appName}:${Date.now()}`
-
-    // Detect workflow apps by checking if the Dockerfile sets WORKFLOW_TARGET_WORLD
-    // to @platformatic/world (our managed workflow service)
-    try {
-      const dockerfile = await readFile(join(directory, 'Dockerfile'), 'utf8')
-      if (/WORKFLOW_TARGET_WORLD\s*=\s*["']?@platformatic\/world["']?/.test(dockerfile)) {
-        isWorkflow = true
-      }
-    } catch {
-      // Dockerfile not found or unreadable — skip detection
-    }
-
-    await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc })
-  } else {
-    appName = appImage.split(':')[0].split('/').pop()
-  }
-
   const envVars = {}
   if (args.envfile) {
     dotenv.config({
@@ -93,6 +71,27 @@ export default async function cli (argv) {
       processEnv: envVars
     })
   }
+
+  let appImage = args.image
+  let appName
+  let directory
+  let dockerfile = ''
+  if (args.dir) {
+    directory = resolve(args.dir)
+    appName = basename(directory).split(sep).pop()
+    appImage = `plt.localreg/plt-local/${appName}:${Date.now()}`
+
+    try {
+      dockerfile = await readFile(join(directory, 'Dockerfile'), 'utf8')
+    } catch {
+      // Dockerfile not found or unreadable; the env file can still declare a workflow.
+    }
+  } else {
+    appName = imageName(appImage)
+  }
+
+  const isWorkflow = detectWorkflow(dockerfile, envVars)
+  if (directory) await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc })
 
   const clusterStatus = await getClusterStatus({ context })
   if (clusterStatus.kafka?.connectionString) {
@@ -145,19 +144,26 @@ export default async function cli (argv) {
       namespace: args.namespace,
       minReplicas,
       maxReplicas,
-      env: Object.keys(envVars).length ? envVars : undefined
+      env: Object.keys(envVars).length ? envVars : undefined,
+      expirePolicy: isWorkflow ? 'workflow' : undefined
     })
+    if (result.pendingApply && result.plan?.length) {
+      const planNamespace = result.plan.find(step => step.manifest)?.manifest?.metadata?.namespace || args.namespace || 'platformatic'
+      await writeAndPrintPlan(context, planNamespace, result.plan, { intent: 'deploy' })
+      return
+    }
     handleIccDeploy(result)
     return
   }
 
-  await deploy.createDeployment(appName, appImage, args.namespace, envVars, args['dry-run'], { context, version, isWorkflow, hostname, minReplicas, maxReplicas })
-  const serviceName = await deploy.createService(appName, appImage, args.namespace, args['dry-run'], { context, version, isWorkflow, headless: args.headless })
+  const namespace = args.namespace || 'platformatic'
+  await deploy.createDeployment(appName, appImage, namespace, envVars, args['dry-run'], { context, version, isWorkflow, hostname, minReplicas, maxReplicas })
+  const serviceName = await deploy.createService(appName, appImage, namespace, args['dry-run'], { context, version, isWorkflow, headless: args.headless })
 
   if (args.headless) {
     if (!args['dry-run']) {
       info('\nHeadless service deploying. No gateway route will be created.')
-      info(`DNS: ${appName}.${args.namespace}.svc.cluster.local`)
+      info(`DNS: ${appName}.${namespace}.svc.cluster.local`)
     }
   } else if (version) {
     // Versioned deploys route through Gateway API HTTPRoutes managed by ICC
@@ -171,7 +177,7 @@ export default async function cli (argv) {
   } else {
     // Create a basic HTTPRoute for the non-versioned deploy.
     // ICC will replace this HTTPRoute when the first versioned deploy arrives.
-    await deploy.createHTTPRoute(appName, args.namespace, args['dry-run'], { context, hostname, serviceName })
+    await deploy.createHTTPRoute(appName, namespace, args['dry-run'], { context, hostname, serviceName })
 
     if (!args['dry-run']) {
       info('\nApplication deploying. It may take some time to see it available.')

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -14,6 +14,7 @@ function resourceVersion (version, imageNameTag) {
 }
 
 export async function createDeployment (name, imageNameTag, namespace, envVars, dryRun, { context, version, isWorkflow, hostname, minReplicas, maxReplicas }) {
+  const reservedEnv = new Set(['PLT_INSTANCE_ID', 'PLT_DEPLOYMENT_VERSION', 'PLT_WORLD_APP_ID', 'PLT_WORLD_DEPLOYMENT_VERSION'])
   const defaultResources = {
     // Minimum
     requests: {
@@ -117,7 +118,9 @@ export async function createDeployment (name, imageNameTag, namespace, envVars, 
                 failureThreshold: 15
               },
               env: [
-                ...Object.entries(envVars).map(([name, value]) => ({ name, value })),
+                ...Object.entries(envVars)
+                  .filter(([name]) => !reservedEnv.has(name))
+                  .map(([name, value]) => ({ name, value })),
                 {
                   name: 'PLT_INSTANCE_ID',
                   valueFrom: { fieldRef: { fieldPath: 'metadata.name' } }
@@ -127,8 +130,13 @@ export async function createDeployment (name, imageNameTag, namespace, envVars, 
                 // is the single point that mints a version, and delivers it to the pod
                 // via the registration response (watt-extra sets PLT_DEPLOYMENT_VERSION).
                 ...(isWorkflow && version
-                  ? [{ name: 'PLT_WORLD_DEPLOYMENT_VERSION', value: version }]
-                  : []),
+                  ? [
+                      { name: 'PLT_WORLD_APP_ID', value: nameLabel },
+                      { name: 'PLT_WORLD_DEPLOYMENT_VERSION', value: version }
+                    ]
+                  : isWorkflow
+                    ? [{ name: 'PLT_WORLD_APP_ID', value: nameLabel }]
+                    : []),
               ],
               resources: defaultResources
             }

--- a/lib/icc.js
+++ b/lib/icc.js
@@ -1,15 +1,13 @@
 import { addToRun } from './run-directory.js'
 import { info, warn } from './utils.js'
 
-// Drive a deploy through ICC's deploy API instead of templating + applying the
-// workload directly. ICC creates the Deployment + Service itself (the deploy API
-// always applies); the pod then registers and the version goes active. The
-// read-only manifests are available via /deploy/plan (getDeployPlan).
+// Drive a deploy through ICC's deploy API instead of templating the workload
+// locally. Manage mode applies it; advise mode returns a plan for the caller.
 //
 // Auth is a scoped deploy token (Bearer plt_deploy_...), the same CI path a
 // customer would use. icc.plt uses a local/self-signed cert, so TLS verification
 // is disabled for this call (dev/testing tool).
-export async function deployViaIcc ({ iccUrl, appId, token, image, version, hostname, namespace, minReplicas, maxReplicas, env }) {
+export async function deployViaIcc ({ iccUrl, appId, token, image, version, hostname, namespace, minReplicas, maxReplicas, env, expirePolicy }) {
   // With an app id: the app-scoped route. Without: the token-scoped route, where
   // ICC resolves the application from the deploy token (a CI needs only the token).
   const base = iccUrl.replace(/\/+$/, '')
@@ -23,6 +21,7 @@ export async function deployViaIcc ({ iccUrl, appId, token, image, version, host
   if (minReplicas) body.minReplicas = minReplicas
   if (maxReplicas) body.maxReplicas = maxReplicas
   if (env && Object.keys(env).length) body.env = env
+  if (expirePolicy) body.expirePolicy = expirePolicy
 
   const prevTls = process.env.NODE_TLS_REJECT_UNAUTHORIZED
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
@@ -45,8 +44,8 @@ export async function deployViaIcc ({ iccUrl, appId, token, image, version, host
   }
 }
 
-// Report the outcome of an ICC deploy. The deploy API always creates the
-// workload, so the response is { deployed: true, controllerName, serviceName }.
+// Report the outcome of a manage-mode ICC deploy. Advise plans are handled by
+// the deploy CLI before this function is called.
 export function handleIccDeploy (result) {
   if (result.deployed) {
     info(`\nICC created the workload (${result.controllerName ?? 'Deployment'} + Service). The pod will register and the version will go active.`)

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -1,0 +1,61 @@
+function unquote (value) {
+  const quote = value[0]
+  if ((quote === '"' || quote === "'") && value.at(-1) === quote) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+function parseBoolean (value, source) {
+  const normalized = unquote(String(value).trim())
+  if (normalized === 'true') return true
+  if (normalized === 'false') return false
+  throw new Error(`Invalid PLT_WORKFLOW value in ${source}: expected "true" or "false", received "${normalized}"`)
+}
+
+function dockerfileEnv (dockerfile) {
+  let env = {}
+  const stages = new Map()
+  const logicalLines = dockerfile.replace(/\\\r?\n/g, ' ').split(/\r?\n/)
+
+  for (const line of logicalLines) {
+    const from = /^\s*FROM(?:\s+--\S+)?\s+(\S+)(?:\s+AS\s+(\S+))?\s*$/i.exec(line)
+    if (from) {
+      env = { ...(stages.get(from[1].toLowerCase()) || {}) }
+      if (from[2]) stages.set(from[2].toLowerCase(), env)
+      continue
+    }
+
+    const instruction = /^\s*ENV\s+(.+)$/i.exec(line)
+    if (!instruction) continue
+
+    const args = instruction[1].trim()
+    const keyValue = /(?:^|\s)([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|'[^']*'|[^\s]*)/g
+    let match
+    let foundKeyValue = false
+    while ((match = keyValue.exec(args)) !== null) {
+      foundKeyValue = true
+      env[match[1]] = unquote(match[2])
+    }
+
+    if (!foundKeyValue) {
+      const keySpaceValue = /^([A-Za-z_][A-Za-z0-9_]*)\s+(.+)$/.exec(args)
+      if (keySpaceValue) env[keySpaceValue[1]] = unquote(keySpaceValue[2].trim())
+    }
+  }
+
+  return env
+}
+
+export function detectWorkflow (dockerfile = '', env = {}) {
+  if (Object.hasOwn(env, 'PLT_WORKFLOW')) {
+    return parseBoolean(env.PLT_WORKFLOW, 'environment file')
+  }
+
+  const dockerEnv = dockerfileEnv(dockerfile)
+  if (Object.hasOwn(dockerEnv, 'PLT_WORKFLOW')) {
+    return parseBoolean(dockerEnv.PLT_WORKFLOW, 'Dockerfile ENV')
+  }
+
+  return dockerEnv.WORKFLOW_TARGET_WORLD === '@platformatic/world'
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: true

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -1,0 +1,51 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createDeployment } from '../lib/deploy.js'
+import { imageName } from '../cli/deploy.js'
+
+test('imageName handles registry ports, tags, and digests', () => {
+  assert.equal(imageName('localhost:5000/orders:v2'), 'orders')
+  assert.equal(imageName('registry.example/orders@sha256:abc'), 'orders')
+})
+
+test('workflow deployment has authoritative world metadata', async () => {
+  const runDir = await mkdtemp(join(tmpdir(), 'desk-deploy-'))
+
+  try {
+    await createDeployment('orders', 'registry/orders:v2', 'platformatic', {
+      PLT_INSTANCE_ID: 'overridden',
+      PLT_DEPLOYMENT_VERSION: 'overridden',
+      PLT_WORLD_APP_ID: 'wrong-app',
+      PLT_WORLD_DEPLOYMENT_VERSION: 'wrong-version',
+      USER_ENV: 'preserved'
+    }, true, {
+      context: { runDir },
+      version: 'v2',
+      isWorkflow: true
+    })
+
+    const manifest = JSON.parse(await readFile(join(runDir, 'deployment.json'), 'utf8'))
+    const env = manifest.spec.template.spec.containers[0].env
+    assert.deepEqual(manifest.metadata.labels, {
+      'app.kubernetes.io/name': 'orders',
+      'app.kubernetes.io/instance': 'orders-v2',
+      'plt.dev/version': 'v2',
+      'plt.dev/workflow': 'true'
+    })
+    assert.equal(manifest.spec.template.metadata.labels['app.kubernetes.io/name'], 'orders')
+    assert.deepEqual(env.filter(entry => entry.name === 'PLT_WORLD_APP_ID'), [
+      { name: 'PLT_WORLD_APP_ID', value: manifest.metadata.labels['app.kubernetes.io/name'] }
+    ])
+    assert.deepEqual(env.filter(entry => entry.name === 'PLT_WORLD_DEPLOYMENT_VERSION'), [
+      { name: 'PLT_WORLD_DEPLOYMENT_VERSION', value: 'v2' }
+    ])
+    assert.equal(env.find(entry => entry.name === 'USER_ENV').value, 'preserved')
+    assert.equal(env.filter(entry => entry.name === 'PLT_INSTANCE_ID').length, 1)
+    assert.equal(env.some(entry => entry.name === 'PLT_DEPLOYMENT_VERSION'), false)
+  } finally {
+    await rm(runDir, { recursive: true, force: true })
+  }
+})

--- a/tests/icc.test.js
+++ b/tests/icc.test.js
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert'
+import { afterEach, test } from 'node:test'
+import { deployViaIcc } from '../lib/icc.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test('deployViaIcc sends workflow expiry policy', async () => {
+  let request
+  globalThis.fetch = async (url, options) => {
+    request = { url, options }
+    return { ok: true, text: async () => '{"deployed":true}' }
+  }
+
+  await deployViaIcc({
+    iccUrl: 'https://icc.plt',
+    token: 'token',
+    image: 'registry/orders:v2',
+    version: 'v2',
+    expirePolicy: 'workflow'
+  })
+
+  assert.equal(request.url, 'https://icc.plt/control-plane/deploy')
+  assert.equal(JSON.parse(request.options.body).expirePolicy, 'workflow')
+})
+
+test('deployViaIcc omits expiry policy for non-workflow deployments', async () => {
+  let body
+  globalThis.fetch = async (url, options) => {
+    body = JSON.parse(options.body)
+    return { ok: true, text: async () => '{"deployed":true}' }
+  }
+
+  await deployViaIcc({
+    iccUrl: 'https://icc.plt',
+    token: 'token',
+    image: 'registry/orders:v2',
+    version: 'v2'
+  })
+
+  assert.equal(Object.hasOwn(body, 'expirePolicy'), false)
+})

--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import dotenv from 'dotenv'
+import { detectWorkflow } from '../lib/workflow.js'
+
+test('detectWorkflow recognizes Dockerfile ENV declaration forms', () => {
+  assert.equal(detectWorkflow('ENV PLT_WORKFLOW=true'), true)
+  assert.equal(detectWorkflow('ENV PLT_WORKFLOW true'), true)
+})
+
+test('detectWorkflow treats explicit false as authoritative', () => {
+  assert.equal(detectWorkflow('ENV PLT_WORKFLOW=false\nENV WORKFLOW_TARGET_WORLD=@platformatic/world'), false)
+  assert.equal(detectWorkflow('ENV PLT_WORKFLOW=true', { PLT_WORKFLOW: 'false' }), false)
+})
+
+test('detectWorkflow rejects invalid explicit values', () => {
+  assert.throws(() => detectWorkflow('ENV PLT_WORKFLOW=yes'), /Invalid PLT_WORKFLOW value in Dockerfile ENV/)
+  assert.throws(() => detectWorkflow('', { PLT_WORKFLOW: '1' }), /Invalid PLT_WORKFLOW value in environment file/)
+})
+
+test('detectWorkflow ignores comments and arbitrary text', () => {
+  assert.equal(detectWorkflow('# ENV PLT_WORKFLOW=true\nRUN echo PLT_WORKFLOW=true'), false)
+})
+
+test('detectWorkflow does not classify a local world target', () => {
+  assert.equal(detectWorkflow('ENV WORKFLOW_TARGET_WORLD=http://world.platformatic.svc.cluster.local'), false)
+})
+
+test('detectWorkflow supports the legacy managed world declaration', () => {
+  assert.equal(detectWorkflow('ENV WORKFLOW_TARGET_WORLD=@platformatic/world'), true)
+  assert.equal(detectWorkflow('ENV WORKFLOW_TARGET_WORLD @platformatic/world'), true)
+})
+
+test('detectWorkflow uses the final Dockerfile stage', () => {
+  assert.equal(detectWorkflow(`
+    FROM node AS builder
+    ENV PLT_WORKFLOW=true
+    FROM node AS runtime
+  `), false)
+  assert.equal(detectWorkflow(`
+    FROM node AS builder
+    ENV PLT_WORKFLOW=true
+    FROM builder AS runtime
+  `), true)
+})
+
+test('detectWorkflow classifies an image deployment from an env file', () => {
+  assert.equal(detectWorkflow('', dotenv.parse('PLT_WORKFLOW=true\n')), true)
+})
+
+test('detectWorkflow rejects invalid image deployment env file declarations', () => {
+  assert.throws(
+    () => detectWorkflow('', dotenv.parse('PLT_WORKFLOW=invalid\n')),
+    /Invalid PLT_WORKFLOW value in environment file/
+  )
+})


### PR DESCRIPTION
## Summary

- Add explicit workflow detection through `PLT_WORKFLOW=true|false` in Dockerfiles and env files.
- Preserve the legacy `WORKFLOW_TARGET_WORLD=@platformatic/world` detector as a compatibility fallback.
- Correctly inspect multi-stage Dockerfiles and image references containing registry ports or digests.
- Inject authoritative World application and deployment metadata into workflow workloads.
- Propagate workflow expiry policy to ICC while preserving ICC namespace inheritance.
- Materialize ICC advise-mode deployment plans instead of silently ignoring them.
- Prevent user-provided environment variables from overriding generated deployment metadata.

Assisted-By: OpenAI:GPT-5.6-Sol <openai/gpt-5.6-sol>
