### PR TITLE
feat: thread --version into the image build as PLT_DEPLOYMENT_ID

### DIFF
--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -12,6 +12,23 @@ import { detectWorkflow } from '../lib/workflow.js'
 
 export const options = { command: 'deploy', strict: true }
 
+// Docker build args for a deploy. Query-string skew protection needs ONE value
+// in three places: baked into the client assets as `?dpl=<id>` at build time,
+// set as plt.dev/version on the workload, and therefore used as the gateway's
+// match key. --version is that value, so it has to reach the build as well as
+// the deploy.
+//
+// Exported so this is covered by a test: the failure is silent. Without the
+// build arg the image builds, the workload deploys, and the app runs, but its
+// assets carry no ?dpl, so ICC sees a version that was not built with its own id
+// and correctly refuses to route to it. Nothing errors.
+//
+// An app whose Dockerfile does not declare `ARG PLT_DEPLOYMENT_ID=` simply
+// ignores it.
+export function deployBuildArgs (version) {
+  return version ? { PLT_DEPLOYMENT_ID: version } : {}
+}
+
 export function imageName (image) {
   return image.split('/').at(-1).split('@')[0].split(':')[0]
 }
@@ -92,14 +109,7 @@ export default async function cli (argv) {
 
   const isWorkflow = detectWorkflow(dockerfile, envVars)
 
-  // Query-string skew protection needs ONE value in three places: baked into the
-  // client assets as `?dpl=<id>` at build time, set as plt.dev/version on the
-  // workload, and therefore used as the gateway's match key. --version is that
-  // value, so thread it into the build too. Without this the assets carry no
-  // ?dpl, ICC sees a version that was not built with its own id, and the version
-  // is silently unpinnable. The app's Dockerfile must declare the matching
-  // `ARG PLT_DEPLOYMENT_ID=`; if it does not, this build arg is simply ignored.
-  const buildArgs = args.version ? { PLT_DEPLOYMENT_ID: args.version } : {}
+  const buildArgs = deployBuildArgs(args.version)
   if (directory) await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc, buildArgs })
 
   const clusterStatus = await getClusterStatus({ context })

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -91,7 +91,16 @@ export default async function cli (argv) {
   }
 
   const isWorkflow = detectWorkflow(dockerfile, envVars)
-  if (directory) await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc })
+
+  // Query-string skew protection needs ONE value in three places: baked into the
+  // client assets as `?dpl=<id>` at build time, set as plt.dev/version on the
+  // workload, and therefore used as the gateway's match key. --version is that
+  // value, so thread it into the build too. Without this the assets carry no
+  // ?dpl, ICC sees a version that was not built with its own id, and the version
+  // is silently unpinnable. The app's Dockerfile must declare the matching
+  // `ARG PLT_DEPLOYMENT_ID=`; if it does not, this build arg is simply ignored.
+  const buildArgs = args.version ? { PLT_DEPLOYMENT_ID: args.version } : {}
+  if (directory) await registry.buildFromDirectory(directory, appImage, { npmrc: args.npmrc, buildArgs })
 
   const clusterStatus = await getClusterStatus({ context })
   if (clusterStatus.kafka?.connectionString) {

--- a/profiles/development.yaml
+++ b/profiles/development.yaml
@@ -59,6 +59,7 @@ platformatic:
           check_interval_ms: 10000         # 10 seconds
           traffic_window_ms: 60000         # 1 min
           cookie_max_age: 43200            # 12h in seconds (keep default)
+          default_routing_mode: query       # query | cookie; per-app override in ICC settings
         icc_jobs:
           enable: true
 

--- a/profiles/oss.yaml
+++ b/profiles/oss.yaml
@@ -69,6 +69,7 @@ platformatic:
           check_interval_ms: 10000         # 10 seconds
           traffic_window_ms: 30000         # 30 seconds for e2e testing
           cookie_max_age: 43200            # 12h in seconds (keep default)
+          default_routing_mode: query       # query | cookie; per-app override in ICC settings
         icc_jobs:
           enable: true
 

--- a/profiles/skew-protection.yaml
+++ b/profiles/skew-protection.yaml
@@ -57,6 +57,7 @@ platformatic:
           check_interval_ms: 10000         # 10 seconds
           traffic_window_ms: 60000         # 1 min
           cookie_max_age: 43200            # 12h in seconds (keep default)
+          default_routing_mode: query       # query | cookie; per-app override in ICC settings
         icc_jobs:
           enable: true
 

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createDeployment } from '../lib/deploy.js'
-import { imageName } from '../cli/deploy.js'
+import { imageName, deployBuildArgs } from '../cli/deploy.js'
 
 test('imageName handles registry ports, tags, and digests', () => {
   assert.equal(imageName('localhost:5000/orders:v2'), 'orders')
@@ -48,4 +48,22 @@ test('workflow deployment has authoritative world metadata', async () => {
   } finally {
     await rm(runDir, { recursive: true, force: true })
   }
+})
+
+test('--version reaches the image build as PLT_DEPLOYMENT_ID', () => {
+  // The value has to land in three places at once: the build arg (so the client
+  // assets carry ?dpl=<id>), the plt.dev/version label, and therefore the
+  // gateway's match key. This covers the build-arg half; the label half is
+  // asserted by the createDeployment tests above.
+  assert.deepEqual(deployBuildArgs('v2'), { PLT_DEPLOYMENT_ID: 'v2' })
+  assert.deepEqual(deployBuildArgs('a1b2c3d4e5f6'), { PLT_DEPLOYMENT_ID: 'a1b2c3d4e5f6' })
+})
+
+test('a deploy without --version passes no build args', () => {
+  // Unversioned deploys must build exactly as before. Passing an empty
+  // PLT_DEPLOYMENT_ID would make the framework hooks stamp `?dpl=` on every
+  // asset URL, which matches nothing.
+  assert.deepEqual(deployBuildArgs(undefined), {})
+  assert.deepEqual(deployBuildArgs(null), {})
+  assert.deepEqual(deployBuildArgs(''), {})
 })


### PR DESCRIPTION
`desk deploy -d <dir> -v <version>` built the image and then labelled the workload `plt.dev/version=<version>`, but never told the build what that version was. This passes it through as `--build-arg PLT_DEPLOYMENT_ID=<version>`.

Query-string skew protection needs one value in three places at once: baked into the client assets as `?dpl=<id>` at build time, set as `plt.dev/version` on the workload, and therefore used as the gateway's match key. `--version` is that value, so it has to reach the build as well as the deploy.

Without this the failure is silent, which is why it is worth fixing rather than documenting. The image builds fine, the workload deploys fine, and the app runs fine. But its assets carry no `?dpl`, so ICC sees a version that was not built with its own id, correctly refuses to emit a routing rule for it, and the app simply has no skew protection. Nothing errors.

`lib/registry.js#buildFromDirectory` already accepted a `buildArgs` option; nothing ever populated it.

Deploying without `--version` is unchanged, and an application whose Dockerfile does not declare the matching `ARG PLT_DEPLOYMENT_ID=` ignores the build arg.

### Related

- platformatic/icc-3#975 implements the query routing this feeds.
- platformatic/helm#63 exposes the cluster routing mode.
- platformatic/platformatic#5050 (merged, v3.66.0) does the build-time stamping.

Verified end to end on a k3d cluster: `desk deploy -v <id>` now produces an image whose `ENV` carries `PLT_DEPLOYMENT_ID` and whose built assets carry `?dpl=<id>`, and requests carrying that query reach that version's pod.
