### PR TITLE
fix: pin workflow replicas to 1 like icc

### DIFF
--- a/charts/v4/platformatic/helm/overrides.yaml
+++ b/charts/v4/platformatic/helm/overrides.yaml
@@ -1,6 +1,13 @@
 applicationNamespaces: [{{ PLT_NAMESPACES }}]
 
 services:
+  workflow:
+    # Pin to a single pod like icc below. Without this the chart HPA defaults to
+    # maxReplicas 3 (chart/templates/hpa.yaml: dig "replicas" "max" 3) and scales
+    # workflow up on memory (dev pod ~470Mi vs the 512Mi request > 80% target).
+    replicas:
+      min: 1
+      max: 1
   icc:
     replicas:
       min: 1


### PR DESCRIPTION
The workflow HPA was defaulting to `maxReplicas: 3` (chart `templates/hpa.yaml`: `dig "replicas" "max" 3`) and scaling up on memory, because the dev pod uses ~470Mi against a 512Mi request (over the 80% target). That produced 2-3 workflow pods in local dev. icc doesn't have this problem because `overrides.yaml` already pins it to `min/max 1`; workflow had no such pin, so it fell through to the chart default.

This adds the same `replicas: {min: 1, max: 1}` block for `services.workflow`, mirroring `services.icc`, capping the workflow HPA at a single pod in local dev.
